### PR TITLE
I've aligned the Prometheus metrics with the format you specified and…

### DIFF
--- a/uptime_monitor/Cargo.toml
+++ b/uptime_monitor/Cargo.toml
@@ -14,6 +14,9 @@ actix-web = "4"
 toml = "0.8"
 log = "0.4"
 env_logger = "0.11"
+native-tls = "0.2"
+openssl = "0.10"
+prometheus = { version = "0.13", features = ["process"] }
 
 [dev-dependencies]
 tempfile = "3" # Already added from previous step, ensure it's here

--- a/uptime_monitor/src/api.rs
+++ b/uptime_monitor/src/api.rs
@@ -3,18 +3,26 @@ use std::sync::{Arc, Mutex};
 use crate::monitoring::{TargetStatus, CheckResult};
 use std::fmt::Write;
 use log::{info, error}; // Added log macros
+use prometheus::{Encoder, TextEncoder, Registry, gather};
+use prometheus::process_collector::ProcessCollector;
 
 const CONTENT_TYPE_PROMETHEUS: &str = "text/plain; version=0.0.4; charset=utf-8";
 
 // --- Prometheus Metric Definitions ---
-const HELP_STATUS_HEALTH: &str = "# HELP uptime_status_health Current health status of the target (1=healthy, 0=unhealthy).";
-const TYPE_STATUS_HEALTH: &str = "# TYPE uptime_status_health gauge";
+const HELP_MONITOR_STATUS: &str = "# HELP monitor_status Current health status of the monitor (0=DOWN, 1=UP).";
+const TYPE_MONITOR_STATUS: &str = "# TYPE monitor_status gauge";
 
-const HELP_RESPONSE_TIME: &str = "# HELP uptime_response_time_seconds Last response time in seconds for HTTP/S checks.";
-const TYPE_RESPONSE_TIME: &str = "# TYPE uptime_response_time_seconds gauge";
+const HELP_MONITOR_RESPONSE_TIME: &str = "# HELP monitor_response_time Last response time in milliseconds for HTTP/S checks.";
+const TYPE_MONITOR_RESPONSE_TIME: &str = "# TYPE monitor_response_time gauge";
 
-const HELP_CONSECUTIVE_FAILURES: &str = "# HELP uptime_consecutive_failures_total Total number of consecutive failures for the target.";
-const TYPE_CONSECUTIVE_FAILURES: &str = "# TYPE uptime_consecutive_failures_total counter";
+const HELP_MONITOR_CONSECUTIVE_FAILURES: &str = "# HELP monitor_consecutive_failures Total number of consecutive failures for the monitor.";
+const TYPE_MONITOR_CONSECUTIVE_FAILURES: &str = "# TYPE monitor_consecutive_failures gauge"; // Changed to gauge as per common practice for this type of metric
+
+const HELP_MONITOR_CERT_DAYS_REMAINING: &str = "# HELP monitor_cert_days_remaining The number of days remaining until the certificate expires";
+const TYPE_MONITOR_CERT_DAYS_REMAINING: &str = "# TYPE monitor_cert_days_remaining gauge";
+
+const HELP_MONITOR_CERT_IS_VALID: &str = "# HELP monitor_cert_is_valid Is the certificate still valid? (1 = Yes, 0 = No)";
+const TYPE_MONITOR_CERT_IS_VALID: &str = "# TYPE monitor_cert_is_valid gauge";
 // --- End Prometheus Metric Definitions ---
 
 
@@ -28,74 +36,117 @@ fn escape_label_value(value: &str) -> String {
 async fn metrics_handler(data: web::Data<Arc<Mutex<Vec<TargetStatus>>>>) -> impl Responder {
     let statuses = data.lock().unwrap(); // .unwrap() is okay for this example, but handle errors in prod
 
-    let mut output = String::new();
+    let mut custom_metrics_output = String::new();
 
-    // Add HELP and TYPE lines only once
-    output.push_str(HELP_STATUS_HEALTH);
-    output.push_str("\n");
-    output.push_str(TYPE_STATUS_HEALTH);
-    output.push_str("\n");
+    // General Metrics (apply to all types)
+    custom_metrics_output.push_str(HELP_MONITOR_STATUS);
+    custom_metrics_output.push_str("\n");
+    custom_metrics_output.push_str(TYPE_MONITOR_STATUS);
+    custom_metrics_output.push_str("\n");
 
-    // Buffer for response time metrics, as they might not exist for all targets
-    let mut response_time_metrics = String::new();
-    let mut has_http_metrics = false;
+    let mut status_metrics_buffer = String::new();
 
+    custom_metrics_output.push_str(HELP_MONITOR_CONSECUTIVE_FAILURES);
+    custom_metrics_output.push_str("\n");
+    custom_metrics_output.push_str(TYPE_MONITOR_CONSECUTIVE_FAILURES);
+    custom_metrics_output.push_str("\n");
+    let mut consecutive_failures_buffer = String::new();
 
+    // HTTP Specific Metrics
+    let mut http_metrics_buffer = String::new();
+    let mut has_http_metrics = false; // To know if we need to print HTTP specific HELP/TYPE
+
+    // Iterate once and build up metric strings for custom metrics
     for status in statuses.iter() {
-        let escaped_alias = escape_label_value(&status.target_alias);
-        let check_type = match &status.last_result {
-            Some(CheckResult::Tcp(_)) => "tcp",
-            Some(CheckResult::Http(_)) => "http",
-            None => "unknown", // Or skip if no result yet
-        };
+        let monitor_name = escape_label_value(&status.target_alias);
+        let monitor_url = escape_label_value(&status.monitor_url);
+        let monitor_hostname = escape_label_value(&status.monitor_hostname);
+        let monitor_port = escape_label_value(&status.monitor_port.to_string());
 
-        // uptime_status_health
-        let health_value = if status.is_healthy { 1 } else { 0 };
-        let _ = writeln!(output, "uptime_status_health{{target_alias=\"{}\", check_type=\"{}\"}} {}",
-                         escaped_alias, check_type, health_value);
-
-        // uptime_response_time_seconds (only for HTTP)
-        if let Some(CheckResult::Http(http_details)) = &status.last_result {
-            if !has_http_metrics { // Add HELP/TYPE only if we have at least one HTTP metric
-                response_time_metrics.push_str(HELP_RESPONSE_TIME);
-                response_time_metrics.push_str("\n");
-                response_time_metrics.push_str(TYPE_RESPONSE_TIME);
-                response_time_metrics.push_str("\n");
-                has_http_metrics = true;
-            }
-            let response_time_seconds = http_details.response_time_ms as f64 / 1000.0;
-            let _ = writeln!(response_time_metrics, "uptime_response_time_seconds{{target_alias=\"{}\", check_type=\"{}\"}} {:.3}",
-                             escaped_alias, check_type, response_time_seconds);
-        }
-    }
-
-    // Append response time metrics if any
-    if has_http_metrics {
-        output.push_str(&response_time_metrics);
-    }
-
-    // Add HELP and TYPE for consecutive failures
-    output.push_str(HELP_CONSECUTIVE_FAILURES);
-    output.push_str("\n");
-    output.push_str(TYPE_CONSECUTIVE_FAILURES);
-    output.push_str("\n");
-
-    for status in statuses.iter() {
-        let escaped_alias = escape_label_value(&status.target_alias);
         let check_type = match &status.last_result {
             Some(CheckResult::Tcp(_)) => "tcp",
             Some(CheckResult::Http(_)) => "http",
             None => "unknown",
         };
-        // uptime_consecutive_failures_total
-        let _ = writeln!(output, "uptime_consecutive_failures_total{{target_alias=\"{}\", check_type=\"{}\"}} {}",
-                         escaped_alias, check_type, status.consecutive_failures);
+
+        let labels = format!(
+            "monitor_name=\"{}\",monitor_type=\"{}\",monitor_url=\"{}\",monitor_hostname=\"{}\",monitor_port=\"{}\"",
+            monitor_name, check_type, monitor_url, monitor_hostname, monitor_port
+        );
+
+        // monitor_status
+        let health_value = if status.is_healthy { 1 } else { 0 };
+        let _ = writeln!(status_metrics_buffer, "monitor_status{{{}}} {}", labels, health_value);
+
+        // monitor_consecutive_failures
+        let _ = writeln!(consecutive_failures_buffer, "monitor_consecutive_failures{{{}}} {}", labels, status.consecutive_failures);
+
+        // HTTP specific metrics
+        if let Some(CheckResult::Http(http_details)) = &status.last_result {
+            if !has_http_metrics {
+                has_http_metrics = true; // Mark that we have HTTP metrics to print HELP/TYPE lines later
+            }
+
+            // monitor_response_time
+            let _ = writeln!(http_metrics_buffer, "monitor_response_time{{{}}} {}", labels, http_details.response_time_ms);
+
+            // monitor_cert_days_remaining
+            if let Some(days_remaining) = status.cert_days_remaining {
+                let _ = writeln!(http_metrics_buffer, "monitor_cert_days_remaining{{{}}} {}", labels, days_remaining);
+            }
+
+            // monitor_cert_is_valid
+            let cert_valid_value = if status.cert_is_valid.unwrap_or(false) { 1 } else { 0 };
+            let _ = writeln!(http_metrics_buffer, "monitor_cert_is_valid{{{}}} {}", labels, cert_valid_value);
+        }
     }
+
+    // Append buffered custom metrics to the main custom output
+    custom_metrics_output.push_str(&status_metrics_buffer);
+    custom_metrics_output.push_str(&consecutive_failures_buffer);
+
+    if has_http_metrics {
+        custom_metrics_output.push_str(HELP_MONITOR_RESPONSE_TIME);
+        custom_metrics_output.push_str("\n");
+        custom_metrics_output.push_str(TYPE_MONITOR_RESPONSE_TIME);
+        custom_metrics_output.push_str("\n");
+
+        custom_metrics_output.push_str(HELP_MONITOR_CERT_DAYS_REMAINING);
+        custom_metrics_output.push_str("\n");
+        custom_metrics_output.push_str(TYPE_MONITOR_CERT_DAYS_REMAINING);
+        custom_metrics_output.push_str("\n");
+
+        custom_metrics_output.push_str(HELP_MONITOR_CERT_IS_VALID);
+        custom_metrics_output.push_str("\n");
+        custom_metrics_output.push_str(TYPE_MONITOR_CERT_IS_VALID);
+        custom_metrics_output.push_str("\n");
+
+        custom_metrics_output.push_str(&http_metrics_buffer);
+    }
+
+    // Process Metrics
+    let registry = Registry::new();
+    let process_collector = ProcessCollector::for_self();
+    registry.register(Box::new(process_collector)).expect("ProcessCollector registration failed");
+
+    let mut buffer = Vec::new();
+    let encoder = TextEncoder::new();
+    let process_metric_families = registry.gather();
+    encoder.encode(&process_metric_families, &mut buffer).expect("Failed to encode process metrics");
+    let process_metrics_string = String::from_utf8(buffer).unwrap_or_default();
+
+    // Combine custom metrics and process metrics
+    // Adding a newline if custom_metrics_output is not empty and process_metrics_string is not empty
+    let final_output = if !custom_metrics_output.is_empty() && !process_metrics_string.is_empty() {
+        format!("{}\n{}", custom_metrics_output, process_metrics_string)
+    } else {
+        format!("{}{}", custom_metrics_output, process_metrics_string)
+    };
 
 
     HttpResponse::Ok()
         .content_type(CONTENT_TYPE_PROMETHEUS)
-        .body(output)
+        .body(final_output)
 }
 
 pub async fn start_web_server(
@@ -115,4 +166,220 @@ pub async fn start_web_server(
         error!("HTTP server run failed: {}", e);
         e
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::monitoring::{CheckStatus, HttpCheckResultDetails, TcpCheckResult};
+    use actix_web::body::to_bytes;
+    use actix_web::test as actix_test; // Renamed to avoid conflict
+
+    // Helper to create a TargetStatus for testing
+    fn create_test_target_status(
+        alias: &str,
+        is_healthy: bool,
+        consecutive_failures: u32,
+        monitor_url: &str,
+        monitor_hostname: &str,
+        monitor_port: u16,
+        check_result: Option<CheckResult>,
+        cert_days: Option<i64>,
+        cert_valid: Option<bool>,
+    ) -> TargetStatus {
+        TargetStatus {
+            target_alias: alias.to_string(),
+            last_check_time: None, // Not directly relevant for metrics output structure
+            last_result: check_result,
+            consecutive_failures,
+            is_healthy,
+            uptime_percentage_24h: 0.0, // Placeholder
+            average_response_time_24h_ms: 0.0, // Placeholder
+            monitor_url: monitor_url.to_string(),
+            monitor_hostname: monitor_hostname.to_string(),
+            monitor_port,
+            cert_days_remaining: cert_days,
+            cert_is_valid: cert_valid,
+        }
+    }
+
+    #[actix_web::test]
+    async fn test_metrics_handler_empty_status_list() {
+        let statuses = Arc::new(Mutex::new(Vec::<TargetStatus>::new()));
+        let data = web::Data::new(statuses);
+
+        // Directly calling the handler as it's an async function
+        let resp = metrics_handler(data).await;
+        let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        // Check for process metrics (any common one)
+        assert!(body_str.contains("process_cpu_seconds_total"));
+
+        // Check for custom metric HELP/TYPE lines
+        assert!(body_str.contains(HELP_MONITOR_STATUS));
+        assert!(body_str.contains(TYPE_MONITOR_STATUS));
+        assert!(body_str.contains(HELP_MONITOR_CONSECUTIVE_FAILURES));
+        assert!(body_str.contains(TYPE_MONITOR_CONSECUTIVE_FAILURES));
+
+        // Check that HTTP specific HELP/TYPE lines are NOT present if no HTTP metrics
+        assert!(!body_str.contains(HELP_MONITOR_RESPONSE_TIME));
+        assert!(!body_str.contains(TYPE_MONITOR_RESPONSE_TIME));
+        assert!(!body_str.contains(HELP_MONITOR_CERT_DAYS_REMAINING));
+        assert!(!body_str.contains(TYPE_MONITOR_CERT_DAYS_REMAINING));
+        assert!(!body_str.contains(HELP_MONITOR_CERT_IS_VALID));
+        assert!(!body_str.contains(TYPE_MONITOR_CERT_IS_VALID));
+
+
+        // Check that no actual custom metric data lines are present
+        assert!(!body_str.contains("monitor_status{"));
+        assert!(!body_str.contains("monitor_consecutive_failures{"));
+    }
+
+    #[actix_web::test]
+    async fn test_metrics_handler_mixed_targets() {
+        let statuses_vec = vec![
+            create_test_target_status(
+                "Healthy HTTP Cert OK", true, 0, "https://healthy.example.com", "healthy.example.com", 443,
+                Some(CheckResult::Http(HttpCheckResultDetails {
+                    status: CheckStatus::Healthy,
+                    response_time_ms: 120,
+                    cert_days_remaining: Some(30),
+                    cert_is_valid: Some(true),
+                })), Some(30), Some(true)
+            ),
+            create_test_target_status(
+                "Unhealthy HTTP No Cert", false, 3, "http://unhealthy.example.com", "unhealthy.example.com", 80,
+                Some(CheckResult::Http(HttpCheckResultDetails {
+                    status: CheckStatus::Unhealthy("Timeout".to_string()),
+                    response_time_ms: 5000,
+                    cert_days_remaining: None,
+                    cert_is_valid: None,
+                })), None, None
+            ),
+            create_test_target_status(
+                "Healthy TCP", true, 0, "tcp://healthy.tcp.example.com:1234", "healthy.tcp.example.com", 1234,
+                Some(CheckResult::Tcp(TcpCheckResult { result: Ok(()) })),
+                None, None
+            ),
+            create_test_target_status(
+                "Unhealthy TCP", false, 5, "tcp://unhealthy.tcp.example.com:5678", "unhealthy.tcp.example.com", 5678,
+                Some(CheckResult::Tcp(TcpCheckResult { result: Err("Connection refused".to_string()) })),
+                None, None
+            ),
+        ];
+        let statuses = Arc::new(Mutex::new(statuses_vec));
+        let data = web::Data::new(statuses);
+
+        let resp = metrics_handler(data).await;
+        let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        // Check for process metrics
+        assert!(body_str.contains("process_cpu_seconds_total"));
+
+        // --- Check HELP/TYPE lines ---
+        // General
+        assert_eq!(body_str.matches(HELP_MONITOR_STATUS).count(), 1);
+        assert_eq!(body_str.matches(TYPE_MONITOR_STATUS).count(), 1);
+        assert_eq!(body_str.matches(HELP_MONITOR_CONSECUTIVE_FAILURES).count(), 1);
+        assert_eq!(body_str.matches(TYPE_MONITOR_CONSECUTIVE_FAILURES).count(), 1);
+        // HTTP Specific
+        assert_eq!(body_str.matches(HELP_MONITOR_RESPONSE_TIME).count(), 1);
+        assert_eq!(body_str.matches(TYPE_MONITOR_RESPONSE_TIME).count(), 1);
+        assert_eq!(body_str.matches(HELP_MONITOR_CERT_DAYS_REMAINING).count(), 1);
+        assert_eq!(body_str.matches(TYPE_MONITOR_CERT_DAYS_REMAINING).count(), 1);
+        assert_eq!(body_str.matches(HELP_MONITOR_CERT_IS_VALID).count(), 1);
+        assert_eq!(body_str.matches(TYPE_MONITOR_CERT_IS_VALID).count(), 1);
+
+
+        // --- Check Metric Data Lines ---
+        // Healthy HTTP Cert OK
+        let healthy_http_labels = "monitor_name=\"Healthy HTTP Cert OK\",monitor_type=\"http\",monitor_url=\"https://healthy.example.com\",monitor_hostname=\"healthy.example.com\",monitor_port=\"443\"";
+        assert!(body_str.contains(&format!("monitor_status{{{}}} 1", healthy_http_labels)));
+        assert!(body_str.contains(&format!("monitor_consecutive_failures{{{}}} 0", healthy_http_labels)));
+        assert!(body_str.contains(&format!("monitor_response_time{{{}}} 120", healthy_http_labels)));
+        assert!(body_str.contains(&format!("monitor_cert_days_remaining{{{}}} 30", healthy_http_labels)));
+        assert!(body_str.contains(&format!("monitor_cert_is_valid{{{}}} 1", healthy_http_labels)));
+
+        // Unhealthy HTTP No Cert
+        let unhealthy_http_labels = "monitor_name=\"Unhealthy HTTP No Cert\",monitor_type=\"http\",monitor_url=\"http://unhealthy.example.com\",monitor_hostname=\"unhealthy.example.com\",monitor_port=\"80\"";
+        assert!(body_str.contains(&format!("monitor_status{{{}}} 0", unhealthy_http_labels)));
+        assert!(body_str.contains(&format!("monitor_consecutive_failures{{{}}} 3", unhealthy_http_labels)));
+        assert!(body_str.contains(&format!("monitor_response_time{{{}}} 5000", unhealthy_http_labels)));
+        // Cert metrics should NOT be present for this target
+        assert!(!body_str.contains(&format!("monitor_cert_days_remaining{{{}}}", unhealthy_http_labels)));
+        assert!(body_str.contains(&format!("monitor_cert_is_valid{{{}}} 0", unhealthy_http_labels))); // Should be 0 as None is treated as false
+
+        // Healthy TCP
+        let healthy_tcp_labels = "monitor_name=\"Healthy TCP\",monitor_type=\"tcp\",monitor_url=\"tcp://healthy.tcp.example.com:1234\",monitor_hostname=\"healthy.tcp.example.com\",monitor_port=\"1234\"";
+        assert!(body_str.contains(&format!("monitor_status{{{}}} 1", healthy_tcp_labels)));
+        assert!(body_str.contains(&format!("monitor_consecutive_failures{{{}}} 0", healthy_tcp_labels)));
+        // HTTP specific metrics should NOT be present
+        assert!(!body_str.contains(&format!("monitor_response_time{{{}}}", healthy_tcp_labels)));
+        assert!(!body_str.contains(&format!("monitor_cert_days_remaining{{{}}}", healthy_tcp_labels)));
+        assert!(!body_str.contains(&format!("monitor_cert_is_valid{{{}}}", healthy_tcp_labels)));
+
+
+        // Unhealthy TCP
+        let unhealthy_tcp_labels = "monitor_name=\"Unhealthy TCP\",monitor_type=\"tcp\",monitor_url=\"tcp://unhealthy.tcp.example.com:5678\",monitor_hostname=\"unhealthy.tcp.example.com\",monitor_port=\"5678\"";
+        assert!(body_str.contains(&format!("monitor_status{{{}}} 0", unhealthy_tcp_labels)));
+        assert!(body_str.contains(&format!("monitor_consecutive_failures{{{}}} 5", unhealthy_tcp_labels)));
+    }
+
+    #[actix_web::test]
+    async fn test_metrics_handler_http_no_cert_info() {
+        let statuses_vec = vec![
+            create_test_target_status(
+                "HTTP No Cert Info", true, 0, "http://no.cert.info", "no.cert.info", 80,
+                Some(CheckResult::Http(HttpCheckResultDetails {
+                    status: CheckStatus::Healthy,
+                    response_time_ms: 75,
+                    cert_days_remaining: None, // Explicitly None
+                    cert_is_valid: None,       // Explicitly None
+                })), None, None // TargetStatus also has None for cert fields
+            ),
+        ];
+        let statuses = Arc::new(Mutex::new(statuses_vec));
+        let data = web::Data::new(statuses);
+
+        let resp = metrics_handler(data).await;
+        let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        let labels = "monitor_name=\"HTTP No Cert Info\",monitor_type=\"http\",monitor_url=\"http://no.cert.info\",monitor_hostname=\"no.cert.info\",monitor_port=\"80\"";
+        assert!(body_str.contains(&format!("monitor_status{{{}}} 1", labels)));
+        assert!(body_str.contains(&format!("monitor_response_time{{{}}} 75", labels)));
+
+        // Cert metrics should NOT be present if days_remaining is None
+        assert!(!body_str.contains(&format!("monitor_cert_days_remaining{{{}}}", labels)));
+        // cert_is_valid should be 0 if None
+        assert!(body_str.contains(&format!("monitor_cert_is_valid{{{}}} 0", labels)));
+    }
+     #[actix_web::test]
+    async fn test_escape_label_value_in_metrics() {
+        let statuses_vec = vec![
+            create_test_target_status(
+                "name with \"quotes\" and \\backslash and \nnewline", true, 0,
+                "http://label.test/path", "label.test", 80,
+                Some(CheckResult::Http(HttpCheckResultDetails {
+                    status: CheckStatus::Healthy,
+                    response_time_ms: 50,
+                    cert_days_remaining: None,
+                    cert_is_valid: None,
+                })), None, None
+            ),
+        ];
+        let statuses = Arc::new(Mutex::new(statuses_vec));
+        let data = web::Data::new(statuses);
+
+        let resp = metrics_handler(data).await;
+        let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        // Verify that the special characters in the alias are escaped in the output
+        let expected_escaped_name = "monitor_name=\"name with \\\"quotes\\\" and \\\\backslash and \\nnewline\"";
+        assert!(body_str.contains(expected_escaped_name));
+        assert!(body_str.contains(&format!("monitor_status{{{},monitor_type=\"http\",monitor_url=\"http://label.test/path\",monitor_hostname=\"label.test\",monitor_port=\"80\"}} 1", expected_escaped_name)));
+    }
 }


### PR DESCRIPTION
… added new features.

This update refactors the Prometheus metrics generation to match your provided format and introduces new capabilities:

1.  **Metric Naming and Labels:**
    *   I've renamed metrics from `uptime_*` to `monitor_*` (e.g., `uptime_status_health` to `monitor_status`).
    *   I've standardized labels to `monitor_name`, `monitor_type`, `monitor_url`, `monitor_hostname`, and `monitor_port`.
    *   `monitor_response_time` is now reported in milliseconds.

2.  **Certificate Monitoring (for HTTPS targets):**
    *   I've added `monitor_cert_days_remaining`: a gauge indicating days until SSL certificate expiry.
    *   I've added `monitor_cert_is_valid`: a gauge indicating SSL certificate validity (1 for valid, 0 for invalid).
    *   `monitoring.rs` now extracts certificate details using `native-tls` and `openssl`.

3.  **Process Metrics:**
    *   I've integrated standard process metrics (CPU, memory, file descriptors) using the `prometheus` crate with its `ProcessCollector`.

4.  **Code Changes:**
    *   In `monitoring.rs`, I've updated `TargetStatus` and `HttpCheckResultDetails` to store additional information (URL components, certificate details). I've also modified `check_http_target` to perform certificate extraction.
    *   In `api.rs`, I've overhauled `metrics_handler` to produce the new metric format, include certificate and process metrics, and use updated HELP/TYPE strings.
    *   In `Cargo.toml`, I've added `native-tls`, `openssl`, and `prometheus` dependencies.

5.  **Testing:**
    *   I've added comprehensive unit tests for `metrics_handler` in `api.rs` to verify the correctness of the output format under various conditions.
    *   I've ensured existing tests in `monitoring.rs` were unaffected.

The metrics endpoint should now provide a richer and more conformant set of data for monitoring your application and its targets.